### PR TITLE
chore(htmltidy2): remove unused variable

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -5,7 +5,6 @@ var path = require('path');
 var spawn = require('child_process').spawn;
 
 // tidy exit codes
-var TIDY_OK = 0;
 var TIDY_WARN = 1;
 var TIDY_ERR = 2;
 


### PR DESCRIPTION
`TIDY_OK` variable is never used after being declared.
Alternatively, it can be commented out for posterity's sake?