### PR TITLE
ci(test): update github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 23]
+
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22, 23]
-
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [18, 20, 22]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/c0b41/htmltidy2",
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
This PR:

-   Replaces EOL Node 21 in test matrix with Node 22, which is the next LTS
-   Removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485)
-   Bumps GitHub Actions to their latest major versions. Main change is they are now using Node 20 instead of 16, which was EOL as of April 2022:
     - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
     - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)