### PR TITLE
perf: add missing `'use strict'` directives

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var tidy = require('../htmltidy').tidy;
 var fs  = require('fs');

--- a/examples/basic2.js
+++ b/examples/basic2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var tidy = require('../htmltidy').tidy;
 tidy('<table><tr><td>badly formatted html</tr>', {
     showErrors: true, // `Error: write EPIPE` if set to true or false

--- a/examples/http.js
+++ b/examples/http.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var http = require('http');
 var tidy = require('../htmltidy');

--- a/examples/options.js
+++ b/examples/options.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var tidy = require('../htmltidy').tidy;
 var fs = require('fs');

--- a/examples/pipe.js
+++ b/examples/pipe.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var request = require('request');
 var tidy = require('../htmltidy');

--- a/htmltidy.js
+++ b/htmltidy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var { Stream } = require('stream');
 var { inherits } = require('util');
 var fs = require('fs');

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   testTimeout: 20 * 1000,
 }

--- a/test/tidy.test.js
+++ b/test/tidy.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { tidy } = require('../htmltidy')
 const fs = require('fs')
 


### PR DESCRIPTION
This PR adds missing `'use strict'` directives to the cjs files in this repo. Strict mode can improve performance by eliminating some JavaScript features that hinder optimizations. It also helps avoid subtle bugs by enforcing more consistent scoping and variable declarations.

The [MDN article on strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) alludes to it, but the V8 JS engine used by Node will use more optimised execution paths when strict mode is enabled. See [related Stack Overflow discussion](https://stackoverflow.com/questions/38411552/why-use-strict-improves-performance-10x-in-this-example) for an example.