### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,6 @@
 
 var tidy = require('../htmltidy').tidy;
-var fs  = require('fs');
+var fs  = require('node:fs');
 var text = '<table><tr><td>badly formatted html</tr>';
 
 // default options

--- a/examples/http.js
+++ b/examples/http.js
@@ -1,7 +1,7 @@
 
-var http = require('http');
+var http = require('node:http');
 var tidy = require('../htmltidy');
-var fs = require('fs');
+var fs = require('node:fs');
 
 // setup options
 var opts = {

--- a/examples/options.js
+++ b/examples/options.js
@@ -1,6 +1,6 @@
 
 var tidy = require('../htmltidy').tidy;
-var fs = require('fs');
+var fs = require('node:fs');
 
 
 var text = '<table><tr><td>badly formatted html</tr>';

--- a/htmltidy.js
+++ b/htmltidy.js
@@ -1,8 +1,8 @@
-var { Stream } = require('stream');
-var { inherits } = require('util');
-var fs = require('fs');
-var path = require('path');
-var { spawn } = require('child_process');
+var { Stream } = require('node:stream');
+var { inherits } = require('node:util');
+var fs = require('node:fs');
+var path = require('node:path');
+var { spawn } = require('node:child_process');
 
 // tidy exit codes
 var TIDY_WARN = 1;

--- a/test/tidy.test.js
+++ b/test/tidy.test.js
@@ -1,5 +1,5 @@
 const { tidy } = require('../htmltidy')
-const fs = require('fs')
+const fs = require('node:fs')
 
 describe('Htmltidy2 Tests ', function () {
   test('Test basic : ', function (done) {


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).